### PR TITLE
A missing symbol in documentation (string->symbol)

### DIFF
--- a/srfi-172.html
+++ b/srfi-172.html
@@ -105,7 +105,7 @@ and there is nothing this SRFI can do about it.
 
 <h1>Specification</h1>
 
-<p>The library <code>(srfi 172)</code> includes the following 284 variables
+<p>The library <code>(srfi 172)</code> includes the following 285 variables
 and syntax keywords from R7RS-small.  They are believed to be safe in the
 sense that they cannot affect or be affected by the outside world except
 through the arguments passed to them.
@@ -354,6 +354,7 @@ string&gt;?
 string&gt;=?
 string-&gt;list
 string-&gt;number
+string-&gt;symbol
 string-&gt;utf8
 string-&gt;vector
 string-append
@@ -423,7 +424,7 @@ except for:
 <li>the 4 procedures whose names begin with <code>write</code></li>
 </ul>
 <p>
-It therefore exports 251 identifiers.
+It therefore exports 252 identifiers.
 </p>
 
 <p>


### PR DESCRIPTION
Hi.
I found a missing symbol in documentation.
The missing symbol is `string->symbol`.
It contained in reference implementation but not in documentation.
https://github.com/scheme-requests-for-implementation/srfi-172/blob/d13a1174cb638155bbb008eb92d5fd3311e79622/srfi-172-functional.sld#L43

Regards,
Masaomi CHIBA